### PR TITLE
Update the streaming AI bot to be more easy to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0] - 2023-06-25
+### Changed
+- Updated OpenAIStreamingTool
+  - messages is now an initialization parameter. These messages are then added to the prompt.
+  - response can now take no arguments and will return the response based on the @messages present.
+- Changed the default OpenAI model to be gpt-3.5-turbo rather than gpt-4 due to restrictions with gpt-4.
+
 ## [0.1.6] - 2023-06-01
 ### Changed
 - Fixed bug introduced in 0.1.3 for OpenAIStreamingTool

--- a/lib/ruby_bots/bots/router_bot.rb
+++ b/lib/ruby_bots/bots/router_bot.rb
@@ -1,6 +1,6 @@
 module RubyBots
   # Class to provide a router to different tools.
-  # This bot connects to the OpenAI API and uses gpt-4 by default to choose a proper tool to route the user's input.
+  # This bot connects to the OpenAI API and uses gpt-3.5-turbo by default to choose a proper tool to route the user's input.
   # The bot will only select and use one tool by default.
   class RouterBot < OpenAIBot
     DEFAULT_DESCRIPTION = <<~DESCRIPTION.strip_heredoc

--- a/lib/ruby_bots/tools/openai_streaming_tool.rb
+++ b/lib/ruby_bots/tools/openai_streaming_tool.rb
@@ -1,18 +1,31 @@
 module RubyBots
   class OpenAIStreamingTool < OpenAIChatTool
-    def run(input, &block)
-      @messages = [
-        { role: :system, content: system_instructions },
-        { role: :user, content: input }
-      ]
+    def initialize(name: 'OpenAI Streaming Tool', description: DEFAULT_DESCRIPTION, messages: nil)
+      @messages = messages || []
+      super(name:, description:)
+    end
+
+    def response
+      super('')
+    end
+
+    private
+
+    def run(input)
+      messages = [
+        { role: :system, content: system_instructions }
+      ] + @messages
+      unless input.empty?
+        messages += [
+          { role: :user, content: input }
+        ]
+      end
 
       client.chat(
         parameters: {
-          messages: @messages,
-          model: 'gpt-4',
-          temperature: 0.7,
+          messages:,
           stream: stream_proc
-        }
+        }.merge(default_params)
       )
     end
 

--- a/lib/ruby_bots/tools/openai_tool.rb
+++ b/lib/ruby_bots/tools/openai_tool.rb
@@ -16,7 +16,7 @@ module RubyBots
 
     def default_params
       {
-        model: 'gpt-4',
+        model: 'gpt-3.5-turbo',
         temperature: 0
       }
     end

--- a/lib/ruby_bots/version.rb
+++ b/lib/ruby_bots/version.rb
@@ -1,3 +1,3 @@
 module RubyBots
-  VERSION = '0.1.6'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
This change will allow users to add `message` directly to the streaming chat tool and make it easier to append messages and make an ongoing conversation.

I also created a demo rails app to show how it works and reference it in the readme. I may write a short blog post about it as well.